### PR TITLE
Use secure links

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
 
 html,
 body {

--- a/default.hbs
+++ b/default.hbs
@@ -58,7 +58,7 @@
         (function () {
             var s = document.createElement('script'); s.async = true;
             s.type = 'text/javascript';
-            s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+            s.src = 'https://' + disqus_shortname + '.disqus.com/count.js';
             (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
         }());
         </script>

--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -14,8 +14,8 @@
                     <li><a href="{{url absolute="true"}}">{{label}}</a></li>
                 {{/foreach}}
 
-                <li><a href="http://github.com/GITHUB" target="_blank"><i class="fa fa-github fa-lg"></i></a></li>
-                <li><a href="http://twitter.com/TWITTER" target="_blank"><i class="fa fa-twitter fa-lg"></i></a></li>
+                <li><a href="https://github.com/GITHUB" target="_blank"><i class="fa fa-github fa-lg"></i></a></li>
+                <li><a href="https://twitter.com/TWITTER" target="_blank"><i class="fa fa-twitter fa-lg"></i></a></li>
                 <!--<li><a href="" target="_blank"><i class="fa fa-linkedin"></i></a></li>-->
                 <li><a href="" target="_blank"><i class="fa fa-instagram"></i></a></li>
                 <li><a href="{{@blog.url}}/rss/"><i class="fa fa-rss"></i></a></li>

--- a/post.hbs
+++ b/post.hbs
@@ -36,6 +36,6 @@
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
         </script>
-        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+        <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
     </article>
 </main>


### PR DESCRIPTION
This prevents 'trying to load scripts from unauthenticated sources'
error in Chrome address bar.